### PR TITLE
[#24] Fix focus state for identity logo in main menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,9 @@
 
 <header>
     <div class="masthead">
-        <h1><a class="identity-logo" href="#">Creative Commons</a></h1>
+        <div class="identity-logo-wrapper" tabindex="0">
+            <h1><a class="identity-logo" href="#">Creative Commons</a></h1>
+        </div>
         <button class="expand-menu">Menu</button>
         <nav class="primary-menu">
             <ul>

--- a/src/index.html
+++ b/src/index.html
@@ -224,7 +224,10 @@
 </article>
 
 <footer>
-    <a class="identity-logo" href="#">Creative Commons</a>
+    <div class="identity-logo-wrapper" tabindex="0">
+        <a class="identity-logo" href="#">Creative Commons</a>
+    </div>
+    <!-- <a class="identity-logo" href="#">Creative Commons</a> -->
     
     <nav class="footer-menu">
         <ul>

--- a/src/index.html
+++ b/src/index.html
@@ -14,9 +14,10 @@
 
 <header>
     <div class="masthead">
-        <div class="identity-logo-wrapper" tabindex="0">
-            <h1><a class="identity-logo" href="#">Creative Commons</a></h1>
-        </div>
+        <h1>
+            <span class="identity-logo-wrapper" tabindex="0"></span>
+            <a class="identity-logo" href="#">Creative Commons</a>
+        </h1>
         <button class="expand-menu">Menu</button>
         <nav class="primary-menu">
             <ul>

--- a/src/index.html
+++ b/src/index.html
@@ -225,11 +225,8 @@
 </article>
 
 <footer>
-    <div class="identity-logo-wrapper" tabindex="0">
-        <a class="identity-logo" href="#">Creative Commons</a>
-    </div>
-    <!-- <a class="identity-logo" href="#">Creative Commons</a> -->
-    
+    <span class="identity-logo-wrapper" tabindex="0"></span>
+    <a class="identity-logo" href="#">Creative Commons</a>
     <nav class="footer-menu">
         <ul>
             <li><a href="/about/contact">Contact</a></li>

--- a/src/vocabulary/css/vocabulary.css
+++ b/src/vocabulary/css/vocabulary.css
@@ -86,6 +86,12 @@ body > header {
     margin: 0;
 }
 
+/* allows the child identity-logo element to have a focus state */
+.identity-logo-wrapper {
+    height: 50px;
+    width: 191px;
+}
+
 .masthead .identity-logo {
     display: inline-block;
     text-indent: -1000px;
@@ -108,7 +114,6 @@ body > header {
 
 .masthead .identity-logo:hover {
     background-color: var(--vocabulary-neutral-color-dark-gray);
-
 }
 
 /* TODO: needs focus outline to be fixed */

--- a/src/vocabulary/css/vocabulary.css
+++ b/src/vocabulary/css/vocabulary.css
@@ -90,6 +90,8 @@ body > header {
 .identity-logo-wrapper {
     height: 50px;
     width: 191px;
+    display: block;
+    position: absolute;
 }
 
 .masthead .identity-logo {


### PR DESCRIPTION
## Fixes
Fixes #24 by @possumbilities 

## Description
~~- Changed the HTML structure, so that an `<img>` element is being rendered, instead of just an `<a>` element with children text~~
~~- Created new CSS class rule for this `<img>` element~~
- Created a `<div>` wrapper to maintain the current SVG implementation
- Created a new CSS class rule for the `<div>`
- Duplicated this implementation for the footer

## Technical details
~~I'm not sure this is the best solution, code design-wise. I'm new to the Creative Commons codebase, so totally open to structuring the HTML and CSS differently to fit best practices!~~

## Tests
Tested in the browser to make sure the tab focus state works

## Screenshots
**Before:**
Tab focus would not display on the image because of the `mask-image` css property on it.

<img width="1000" alt="Screenshot 2024-02-25 at 1 53 40 PM" src="https://github.com/creativecommons/index-prototype/assets/52360534/3e716fc4-1b52-4d16-b2c3-5418c03426c1">

**After:**

<img width="1440" alt="Screenshot 2024-02-27 at 10 24 13 PM" src="https://github.com/creativecommons/index-prototype/assets/52360534/dc5903e8-8d54-4516-bd74-2be97f28b231">
<img width="1440" alt="Screenshot 2024-02-27 at 10 24 05 PM" src="https://github.com/creativecommons/index-prototype/assets/52360534/baf51c79-c4c2-4ad5-9c64-d7cb74d0ec05">

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
