### PR TITLE
add pronouns field to person-page context and generalize information

### DIFF
--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -96,6 +96,7 @@
 <header>
 <h1>Mari Moreshead</h1>
 <span class="title">Chief of Staff and Secretary to the Board of Directors</span>
+<span class="pronouns">(they/them)</span>
 <figure>
     <img src="imgs/profile.jpg" />
     <span class="attribution">by Priscilla C. Scott for Creative Commons, licensed under <a href="#">CC BY 4.0</a></span>

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -94,7 +94,7 @@
 <main>
 
 <header>
-<h1>Mari Moreshead</h1>
+<h1>Ólafur Jónsson</h1>
 <span class="title">Chief of Staff and Secretary to the Board of Directors</span>
 <span class="pronouns">(they/them)</span>
 <figure>
@@ -102,10 +102,11 @@
     <span class="attribution">by Priscilla C. Scott for Creative Commons, licensed under <a href="#">CC BY 4.0</a></span>
 </figure>
 <div class="bio">
-<p>Mari came to CC in 2015 after three years at the Mozilla Foundation. Prior to that, she held similar administrative roles at a legal technology start up and the Playful Invention Company. She leads staff engagement, hiring, and other CC operations.</p>
+<p>Ólafur came to CC in 2011 after three years at the Foundation. Prior to that, they held similar roles.</p>
 
-<p>She's lived in a few Canadian cities but now calls Toronto home where she lives with her cats.  When she's not at her desk, she's quilting.</p>
+<p>They currently live on the moon with their three cats and partner, and enjoy textile work and Earth rises.</p>
 </div>
+    
 
 </header>
 


### PR DESCRIPTION
## Fixes

- Fixes #67

## Description
* adds a the pronouns field to match what is present in `vocabulary-theme`
* generalizes the information on `person-page` context.
* https://deploy-preview-68--creativecommons-prototype.netlify.app/context/person-page.html

## Additional Context
* Mari originally gave permission for the photo to be used in the prototype, but we need to create better placeholder images that are more generalized but aren't just a grey square or a logo. ~I'll create an Issue in `vocabulary` to track.~ 
  * https://github.com/creativecommons/vocabulary/issues/39

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
