### PR TITLE
sync upstream Vocabulary markup, correct syntax errors across contexts

### DIFF
--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -251,7 +251,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -268,8 +268,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
 <link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -253,7 +253,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -270,8 +270,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -253,7 +253,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -255,7 +255,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -303,8 +303,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -286,7 +286,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -288,7 +288,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -535,7 +535,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -552,8 +552,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -537,7 +537,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -293,7 +293,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -310,8 +310,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -295,7 +295,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -204,6 +204,7 @@
 
     <li>Top Level Item</li>
 </ul>
+</div>
 
 </main>
 

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -58,7 +58,7 @@
         <ul>
             <li>
                 <a href="#">Global Network</a>
-                <p>Join a  global community working to strengthen the Commons</p>
+                <p>Join a global community working to strengthen the Commons</p>
             </li>
             <li>
                 <a href="#">Certificate</a>

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -226,7 +226,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -224,7 +224,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -241,8 +241,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -130,7 +130,7 @@
         <li>
             <figure>
                 <img src="imgs/home.jpg" />
-                <span class="attribution">“<a href="https://www.flickr.com/photos/niaid/49557785797">Novel Coronavirus SARS-CoV-2” by <a href=https://www.flickr.com/photos/niaid/>NIAID</a>, here cropped, is licensed via <a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a></span>
+                <span class="attribution">“<a href="https://www.flickr.com/photos/niaid/49557785797">Novel Coronavirus SARS-CoV-2</a>” by <a href=https://www.flickr.com/photos/niaid/>NIAID</a>, here cropped, is licensed via <a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a></span>
             </figure>
         </li>
         <li>

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -417,7 +417,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -415,7 +415,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -432,8 +432,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -32,7 +32,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -222,7 +222,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -224,7 +224,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -239,8 +239,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -200,7 +200,7 @@
             <p>In search of answers, we looked at past research, notably Andrea Wallace's Barriers to Open Access — Open GLAM, and asked more than 30 experts in the open culture movement. You can watch what they told us in our CC Open Culture VOICES vlog series. Here's a small sample of what we heard</p>
         </article>
         </li>
-
+    </ul>
 
     </article>
 </article>

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -3,14 +3,14 @@
 <head>
 <title>Program Index - Context</title>
 
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -226,7 +226,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -243,8 +243,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -124,7 +124,7 @@
             </article>
         </li>
         <li>
-            <article class="project"e>
+            <article class="project">
                 <h3><a href="#">Better Internet</a></h3>
                 <p>Find out more about this thing, read more today.</p>
             </article>

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -228,7 +228,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -202,7 +202,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -217,8 +217,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -200,7 +200,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -245,7 +245,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -262,8 +262,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -247,7 +247,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -179,7 +179,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -181,7 +181,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -196,8 +196,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -137,7 +137,7 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
+    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu">
         <ul>

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -5,12 +5,12 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any">
-<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml">
-<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest">
+<link rel="icon" href="../vocabulary/favicon/favicon.ico" sizes="any" />
+<link rel="icon" href="../vocabulary/favicon/favicon.svg" type="image/svg+xml" />
+<link rel="manifest" href="../vocabulary/favicon/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="../vocabulary/favicon/apple-touch-icon.png" />
 
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -152,8 +152,8 @@
 
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -31,7 +31,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -135,7 +135,7 @@
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" media="all" href="css/style.css">
+<link rel="stylesheet" media="all" href="css/style.css" />
 
 </head>
   
@@ -29,7 +29,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->
@@ -257,8 +257,8 @@
     
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <div style="position: absolute; left: -5000px" aria-hidden="true">
           <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">

--- a/src/specimen/product-logo.html
+++ b/src/specimen/product-logo.html
@@ -5,8 +5,8 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" media="all" href="../css/vocabulary/vocabulary.css">
-<link rel="stylesheet" media="all" href="../css/style.css">
+<link rel="stylesheet" media="all" href="../css/vocabulary/vocabulary.css" />
+<link rel="stylesheet" media="all" href="../css/style.css" />
 
 </head>
 
@@ -27,7 +27,7 @@
             </ul>
         </nav>
 
-        <nav class="ancilliary-menu">
+        <nav class="ancillary-menu">
             <ul>
                 <li><button class="locale icon-attach fa-globe">English</button></li>
                 <li><a class="donate icon-attach fa-heart" href="#">Donate</a></li>


### PR DESCRIPTION
## Description
implements upstream Vocabulary changes from:
- https://github.com/creativecommons/vocabulary/pull/134
- https://github.com/creativecommons/vocabulary/pull/136
- https://github.com/creativecommons/vocabulary/pull/175
- https://github.com/creativecommons/vocabulary/pull/180
- https://github.com/creativecommons/vocabulary/pull/214
- https://github.com/creativecommons/vocabulary/pull/233
- https://github.com/creativecommons/vocabulary/pull/237
- https://github.com/creativecommons/vocabulary/pull/240
- https://github.com/creativecommons/vocabulary/pull/261
- https://github.com/creativecommons/vocabulary/pull/281

## Technical details
**Note**: there will be render errors in other areas (see the top menu for example), as this is an ongoing sync across multiple PRs. The Tests below are specifically for the attribution "captions" and their associated renderings.

## Tests
- `archive-page`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/archive-page.html
- `blog-index`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/blog-index.html
-  `blog-post`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/blog-post.html
-  `default-page`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/default-page.html
-  `home-index`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/home-index.html
-  `person-page`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/person-page.html
-  `program-index`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/program-index.html
-  `program-page`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/program-page.html
-  `search-index`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/search-index.html
-  `team-index`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/team-index.html
- `walkthrough-page`: https://deploy-preview-76--creativecommons-prototype.netlify.app/context/walkthrough-page.html


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
