### PR TITLE
remove telephone number from footer

### DIFF
--- a/src/context/archive-page.html
+++ b/src/context/archive-page.html
@@ -254,7 +254,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/blog-index-alt.html
+++ b/src/context/blog-index-alt.html
@@ -256,7 +256,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/blog-index-alt2.html
+++ b/src/context/blog-index-alt2.html
@@ -289,7 +289,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/blog-index.html
+++ b/src/context/blog-index.html
@@ -538,7 +538,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -296,7 +296,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -227,7 +227,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/home-index.html
+++ b/src/context/home-index.html
@@ -418,7 +418,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/person-page.html
+++ b/src/context/person-page.html
@@ -225,7 +225,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/program-index.html
+++ b/src/context/program-index.html
@@ -229,7 +229,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/program-page.html
+++ b/src/context/program-page.html
@@ -203,7 +203,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/search-index.html
+++ b/src/context/search-index.html
@@ -248,7 +248,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/team-index.html
+++ b/src/context/team-index.html
@@ -182,7 +182,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/context/walkthrough-page.html
+++ b/src/context/walkthrough-page.html
@@ -138,7 +138,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>

--- a/src/specimen/product-logo.html
+++ b/src/specimen/product-logo.html
@@ -238,7 +238,6 @@
     <h2>Contact Us</h2>
     <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
-    <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
     <nav class="social-menu" aria-label="Social menu">
         <ul>


### PR DESCRIPTION
## Description
incorporates: 
- https://github.com/creativecommons/vocabulary/pull/309

## Tests
- `archive-page`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/archive-page.html
- `blog-index`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/blog-index.html
-  `blog-post`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/blog-post.html
-  `default-page`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/default-page.html
-  `home-index`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/home-index.html
-  `person-page`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/person-page.html
-  `program-index`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/program-index.html
-  `program-page`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/program-page.html
-  `search-index`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/search-index.html
-  `team-index`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/team-index.html
- `walkthrough-page`: https://deploy-preview-79--creativecommons-prototype.netlify.app/context/walkthrough-page.html

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
