### PR TITLE
correct for wordpress specific `img` alignment classes

### DIFF
--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -111,6 +111,8 @@
 
 </header>
 
+<div class="content">
+
     <aside class="opening">
         <p>
         <span>part of the</span>
@@ -135,6 +137,11 @@
 
     <h3>Along The Way We Try</h3>
 
+    <figure>
+        <img src="../imgs/image.jpg" class="alignright" />
+    
+        <figcaption class="attribution">"<a href="https://thegreats.co/artworks/the-more-we-share-the-more-we-have-series-22">The More We Share, The More We Have (series 1/2)</a>" by <a href="https://thegreats.co/artists/pietro-soldi">Pietro Soldi</a> for Creative Commons &amp; Fine Acts is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a></figcaption>
+    </figure>
 
     <p>Along with 600 million people, nine-year-old Chris Hadfield is glued to his television&mdash;watching intently as American astronaut Neil Armstrong glides down the ladder of the Lunar Module, and in one swift pounce, touches the dust of a familiar yet alien world. His words forever immortalized, "That's one small step for man, one giant leap for mankind."</p>
 
@@ -202,6 +209,8 @@
 
         </ul>
     </article>
+
+    </div>
 
     <article class="posts related">
         <h2>Related posts</h2>
@@ -273,8 +282,6 @@
 
         </ul>
     </article>
-
-
 
 </main>
 

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -188,6 +188,12 @@
     <li>Land safely</li>
 </ol>
 
+<figure>
+    <img src="../imgs/image.jpg" class="alignright" />
+
+    <figcaption class="attribution">"<a href="https://thegreats.co/artworks/the-more-we-share-the-more-we-have-series-22">The More We Share, The More We Have (series 1/2)</a>" by <a href="https://thegreats.co/artists/pietro-soldi">Pietro Soldi</a> for Creative Commons &amp; Fine Acts is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a></figcaption>
+</figure>
+
 <p>For example, Alex G. Orphanos, a science communicator, engineer, and host of the Today in Space podcast, has put NASA's materials to use for over six years. In particular, he has used images from the Hubble Space Telescope and information from NASA Procurement to better explain space-related issues to his audience. Rachael Eidson, a business development specialist for <strong>Trenton Systems</strong> and social media influencer also routinely uses NASA's images in her collaborations with eco-fashion and accessory companies. In fact, it's hard to miss the resurgence of space-themed items, including t-shirts, mugs, bags, etc. featuring NASA's “meatball” logo. As the L.A. Times reported in 2019, “The NASA logo is having a moment.”</p>
 
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -549,3 +549,43 @@ main .content figure:has(img.alignright), .blog-post main figure:has(img.alignri
   width: 40%;
   float: right;
 }
+
+@media (max-width:400px) {
+
+  div[id^="attachment_"].alignleft {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  div[id^="attachment_"].alignright {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content div[id^="attachment_"].alignleft {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+  
+  main .content div[id^="attachment_"].alignright {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content figure:has(img.alignleft), .blog-post main figure:has(img.alignleft) {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content figure:has(img.alignright), .blog-post main figure:has(img.alignright) {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -456,6 +456,96 @@
 
 /* patches */
 
-main > article figure img, main > figure img {
+/* main > article figure img, main > figure img {
   width: 100%;
+} */
+
+/* Classic Editor TinyMCE WYSIWYG editor image alignment  */
+/* TODO: port in alignleft and alignright rules here as well? */
+main figure:has(img.aligncenter) {
+  width: 100%;
+  margin-left: 0;
+}
+
+/* Classic Editor TinyMCE WYSIWYG editor image alignment, previous theme's markukp  */
+/* presently <figure> */
+div[id^="attachment_"] {
+  width: 120%;
+  margin: 0;
+  margin-left: -10%;
+  margin-bottom: 3em;
+  padding: 0;
+  float: none;
+}
+
+/* presently <img> */
+div[id^="attachment_"] img[class^="wp-image"]:not([width]) {
+  width: 100%;
+}
+
+/* presently <span class="attribution> */
+div[id^="attachment_"] p[id^="caption-attachment-"] {
+  display: block;
+  margin-top: 1em;
+  font-size: 1em;
+}
+
+div[id^="attachment_"].alignleft {
+  margin-top: 2em;
+  margin-right: 2em;
+  margin-left: -10%;
+  width: 50%;
+  float: left;
+}
+
+div[id^="attachment_"].alignleft:after {
+  display: block;
+  content: '';
+  height: 3em;
+  clear: both;
+}
+
+div[id^="attachment_"].aligncenter {
+  width: 100%;
+
+  margin-left: 0;
+}
+
+div[id^="attachment_"].alignright {
+  margin-top: 2em;
+  margin-right: -10%;
+  margin-left: 2em;
+  width: 50%;
+  float: right;
+}
+
+div[id^="attachment_"].alignright:after {
+  display: block;
+  content: '';
+  height: 2em;
+  clear: both;
+}
+
+main .content div[id^="attachment_"].alignleft {
+  margin-left: 0;
+  width: 40%;
+}
+
+main .content div[id^="attachment_"].alignright {
+  margin-right: 0;
+  width: 40%;
+}
+
+main .content figure:has(img.alignleft), .blog-post main figure:has(img.alignleft) {
+  margin-right: 2em;
+  margin-left: 0;
+  width: 40%;
+  float: left;
+}
+
+main .content figure:has(img.alignright), .blog-post main figure:has(img.alignright) {
+  margin-right: 0;
+  margin-left: 2em;
+  width: 40%;
+  float: right;
 }


### PR DESCRIPTION
## Description
- Fixes #89 
- adds an `img` with an alignment class of `alignright` to the `default-page` context
- adds an `img` with an alignment class of `alignright` to the `blog-post` context
- adds appropriate localized styling to the `style.css` file to render and test.
- Additionally, this allows for a fix to implement downstream in `vocabulary-theme`:
  - https://github.com/creativecommons/vocabulary-theme/issues/98

**Note:** this rebounds the `blog-post` content to be within a `div.content` wrapper, which fixes the error but violates the grid system in place within Vocabulary. Further explorations are merited to correct for this in the future and reopen the full grid layout capabilities.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
<img width="1018" alt="Screen Shot 2025-03-06 at 2 22 45 PM" src="https://github.com/user-attachments/assets/56e7ea94-66fe-4e83-b453-5b69347ab926" />

## Tests
-  `default-page`: https://deploy-preview-88--creativecommons-prototype.netlify.app/context/default-page.html
-  `blog-post`: https://deploy-preview-88--creativecommons-prototype.netlify.app/context/blog-post.html

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
